### PR TITLE
Add initial support for multi-threaded recording.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ maintenance = { status = "passively-maintained" }
 [features]
 bench_private = [] # for enabling nightly-only feature(test) on the main crate to allow benchmarking private code
 serialization = [ "flate2", "nom", "base64" ]
-sync = []
+sync = [ "crossbeam-channel" ]
 default = [ "serialization", "sync" ]
 
 [dependencies]
@@ -36,6 +36,7 @@ byteorder = "1.0.0"
 flate2 = { version = "1.0", optional = true }
 nom = { version = "^4.0", optional = true }
 base64 = { version = "0.10", optional = true }
+crossbeam-channel = { version = "0.3", optional = true }
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ maintenance = { status = "passively-maintained" }
 [features]
 bench_private = [] # for enabling nightly-only feature(test) on the main crate to allow benchmarking private code
 serialization = [ "flate2", "nom", "base64" ]
-default = [ "serialization" ]
+sync = []
+default = [ "serialization", "sync" ]
 
 [dependencies]
 num-traits = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1845,4 +1845,5 @@ pub mod errors;
 pub mod serialization;
 pub use self::core::counter::*;
 pub use errors::*;
+#[cfg(feature = "sync")]
 pub mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1845,3 +1845,4 @@ pub mod errors;
 pub mod serialization;
 pub use self::core::counter::*;
 pub use errors::*;
+pub mod sync;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -227,6 +227,9 @@ impl<C: Counter> Recorder<C> {
                     if phase != self.last_phase {
                         crit.phased += 1;
                         self.last_phase = phase;
+                        if crit.phased == crit.recorders {
+                            self.shared.all_phased.notify_one();
+                        }
                     }
                     break;
                 }
@@ -338,6 +341,7 @@ impl<C: Counter> SyncHistogram<C> {
                     break;
                 }
             } else {
+                self.shared.phase_change.notify_all();
                 truth = self.shared.all_phased.wait(truth).unwrap();
             }
         }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,352 @@
+//! Synchronized types that allow access to a `Histogram` from multiple threads.
+
+use crate::errors::*;
+use crate::{Counter, Histogram};
+use std::borrow::Borrow;
+use std::sync::{atomic, Arc, Condvar, Mutex};
+
+/// A write-only handle to a [`SyncHistogram`].
+///
+/// This handle allows you to record samples from multiple threads, each with its own `Recorder`,
+/// concurrently. Writes to a `Recorder` are wait-free and scalable except for when the
+/// [`SyncHistogram`] initiates a _phase shift_. During a phase shift, the next write on each
+/// associated `Recorder` merges its results into a shared [`Histogram`] that is then made
+/// available to the [`SyncHistogram`] once the phase shift completes.
+///
+/// An idle `Recorder` will hold up a phase shift indefinitely. If a `Recorder` will remain idle
+/// for extended periods of time, it should call [`Recorder::idle`], which will tell the reader not
+/// to wait for this particular writer.
+#[derive(Debug)]
+pub struct Recorder<C: Counter> {
+    local: Histogram<C>,
+    shared: Arc<Shared<C>>,
+    last_phase: usize,
+}
+
+impl<C: Counter> Clone for Recorder<C> {
+    fn clone(&self) -> Self {
+        // reader will have to wait for one more recorder
+        {
+            let mut truth = self.shared.truth.lock().unwrap();
+            truth.recorders += 1;
+        }
+
+        // new recorder should start with an empty histogram
+        let mut h = self.local.clone();
+        h.clear();
+
+        // new recorder starts at the same phase as we do
+        Recorder {
+            local: h,
+            shared: self.shared.clone(),
+            last_phase: self.last_phase,
+        }
+    }
+}
+
+impl<C: Counter> Drop for Recorder<C> {
+    fn drop(&mut self) {
+        // we'll need to decrement the # of recorders
+        {
+            let mut truth = self.shared.truth.lock().unwrap();
+            truth.recorders -= 1;
+
+            // we have to be careful; we _may_ already have incremented for the ongoing phase!
+            if truth.phased != 0 {
+                // note that we _have_ to do this load under the lock, otherwise a reader may
+                // increment the phase after we read, and before we take the lock above!
+                let phase = self.shared.phase.load(atomic::Ordering::Acquire);
+                if phase == self.last_phase {
+                    // we contributed to the current phased value -- undo that
+                    truth.phased -= 1;
+                }
+            }
+
+            // by decrementing, we _may_ also finish the phase
+            if truth.recorders == truth.phased {
+                self.shared.all_phased.notify_one();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Critical<C: Counter> {
+    /// Will be Some whenever the Histogram is in the process of being phased.
+    merged: Option<Histogram<C>>,
+    recorders: usize,
+    phased: usize,
+}
+
+#[derive(Debug)]
+struct Shared<C: Counter> {
+    truth: Mutex<Critical<C>>,
+    all_phased: Condvar,
+    phase: atomic::AtomicUsize,
+}
+
+/// This guard denotes that a [`Recorder`] is currently idle, and should not be waited on by a
+/// [`SyncHistogram`] phase-shift.
+pub struct IdleRecorderGuard<'a, C: Counter>(&'a mut Recorder<C>);
+
+impl<'a, C: Counter> Drop for IdleRecorderGuard<'a, C> {
+    fn drop(&mut self) {
+        let mut phased = false;
+        // the Recorder is no longer idle, so the reader has to wait for us again
+        // this basically means re-incrementing .recorders
+        {
+            let mut crit = self.0.shared.truth.lock().unwrap();
+            crit.recorders += 1;
+
+            // if there's a phase shift ongoing, we need to take part in that
+            if let Some(ref mut h) = crit.merged {
+                if !self.0.local.is_empty() {
+                    h.add(&self.0.local)
+                        .expect("TODO: failed to merge histogram");
+                    phased = true;
+                }
+                crit.phased += 1;
+            }
+
+            // we are now up-to-date with the current phase
+            // NOTE: we have to load this during the lock so we don't read too early/late
+            self.0.last_phase = self.0.shared.phase.load(atomic::Ordering::Acquire);
+
+            // NOTE: we cannot have finished the phase, since it cannot have been waiting for us.
+        }
+
+        // if we phase shifted, clear the changes we just merged
+        if phased {
+            self.0.local.clear();
+        }
+    }
+}
+
+impl<C: Counter> Recorder<C> {
+    fn with_hist<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Histogram<C>) -> R,
+    {
+        let r = f(&mut self.local);
+        let phase = self.shared.phase.load(atomic::Ordering::Acquire);
+        if phase != self.last_phase {
+            {
+                let mut crit = self.shared.truth.lock().unwrap();
+                if !self.local.is_empty() {
+                    crit.merged
+                        .as_mut()
+                        .expect("no histogram to merge into during phase shift")
+                        .add(&self.local)
+                        .expect("TODO: failed to merge histogram");
+                }
+                crit.phased += 1;
+                if crit.phased == crit.recorders {
+                    self.shared.all_phased.notify_one();
+                }
+            }
+            self.last_phase = phase;
+            self.local.clear();
+        }
+        r
+    }
+
+    /// Call this method if the Recorder will be idle for a while.
+    ///
+    /// Until the returned guard is dropped, the associated [`SyncHistogram`] will not wait for
+    /// this recorder on a phase shift.
+    pub fn idle(&mut self) -> IdleRecorderGuard<C> {
+        let phase;
+        {
+            let mut crit = self.shared.truth.lock().unwrap();
+            phase = self.shared.phase.load(atomic::Ordering::Acquire);
+            if phase != self.last_phase {
+                // if we happen to be in a phase shift, sync our outstanding changes
+                if !self.local.is_empty() {
+                    crit.merged
+                        .as_mut()
+                        .expect("no histogram to merge into during phase shift")
+                        .add(&self.local)
+                        .expect("TODO: failed to merge histogram");
+                }
+            // NOTE; we do _not_ increment .phased, since we're about to decrement .recorders
+            } else if crit.phased != 0 {
+                // we must have already performed this phase shift, and so .phased includes our +1
+                // since we're about to decrement .recorders, we need to also undo that
+                crit.phased -= 1;
+            }
+
+            // make the reader no longer wait for us
+            crit.recorders -= 1;
+
+            // we may have just finished the phase!
+            if crit.phased == crit.recorders {
+                self.shared.all_phased.notify_one();
+            }
+        }
+
+        // if we phase shifted, clear the changes we just merged
+        if phase != self.last_phase {
+            self.last_phase = phase;
+            self.local.clear();
+        }
+
+        IdleRecorderGuard(self)
+    }
+
+    /// See [`Histogram::add`].
+    pub fn add<B: Borrow<Histogram<C>>>(&mut self, source: B) -> Result<(), AdditionError> {
+        self.with_hist(move |h| h.add(source))
+    }
+
+    /// See [`Histogram::add_correct`].
+    pub fn add_correct<B: Borrow<Histogram<C>>>(
+        &mut self,
+        source: B,
+        interval: u64,
+    ) -> Result<(), RecordError> {
+        self.with_hist(move |h| h.add_correct(source, interval))
+    }
+
+    /// See [`Histogram::subtract`].
+    pub fn subtract<B: Borrow<Histogram<C>>>(
+        &mut self,
+        subtrahend: B,
+    ) -> Result<(), SubtractionError> {
+        self.with_hist(move |h| h.subtract(subtrahend))
+    }
+
+    /// See [`Histogram::record`].
+    pub fn record(&mut self, value: u64) -> Result<(), RecordError> {
+        self.with_hist(move |h| h.record(value))
+    }
+
+    /// See [`Histogram::saturating_record`].
+    pub fn saturating_record(&mut self, value: u64) {
+        self.with_hist(move |h| h.saturating_record(value))
+    }
+
+    /// See [`Histogram::record_n`].
+    pub fn record_n(&mut self, value: u64, count: C) -> Result<(), RecordError> {
+        self.with_hist(move |h| h.record_n(value, count))
+    }
+
+    /// See [`Histogram::saturating_record_n`].
+    pub fn saturating_record_n(&mut self, value: u64, count: C) {
+        self.with_hist(move |h| h.saturating_record_n(value, count))
+    }
+
+    /// See [`Histogram::record_correct`].
+    pub fn record_correct(&mut self, value: u64, interval: u64) -> Result<(), RecordError> {
+        self.with_hist(move |h| h.record_correct(value, interval))
+    }
+
+    /// See [`Histogram::record_n_correct`].
+    pub fn record_n_correct(
+        &mut self,
+        value: u64,
+        count: C,
+        interval: u64,
+    ) -> Result<(), RecordError> {
+        self.with_hist(move |h| h.record_n_correct(value, count, interval))
+    }
+}
+
+/// A `Histogram` that can be written to by multiple threads concurrently.
+///
+/// Each writer thread should have a [`Recorder`], which allows it to record new samples without
+/// synchronization. New recorded samples are made available through this histogram by calling
+/// [`phase`], which blocks until it has synchronized with every recorder.
+pub struct SyncHistogram<C: Counter> {
+    /// Will be None during a phase shift.
+    merged: Option<Histogram<C>>,
+    shared: Arc<Shared<C>>,
+}
+
+impl<C: Counter> SyncHistogram<C> {
+    /// Block until writes from all [`Recorder`] instances for this histogram have been
+    /// incorporated.
+    pub fn phase(&mut self) {
+        let mut truth = self.shared.truth.lock().unwrap();
+
+        // provide histogram for writers to merge into
+        truth.merged = self.merged.take();
+        assert_eq!(truth.phased, 0);
+
+        // tell writers to phase
+        let _ = self.shared.phase.fetch_add(1, atomic::Ordering::AcqRel);
+
+        // wait for writers to all have phased
+        // TODO: what if writers are inactive?
+        while truth.phased != truth.recorders {
+            truth = self.shared.all_phased.wait(truth).unwrap();
+        }
+
+        // take the merged histogram back out
+        self.merged = truth.merged.take();
+
+        // reset for next phase
+        truth.phased = 0;
+    }
+
+    /// Obtain another multi-threaded writer for this histogram.
+    ///
+    /// Note that writes made to the `Recorder` will not be visible until the next call to
+    /// [`phase`].
+    pub fn recorder(&self) -> Recorder<C> {
+        // we will have to wait for one more recorder
+        {
+            let mut truth = self.shared.truth.lock().unwrap();
+            truth.recorders += 1;
+        }
+
+        // new recorder should start with an empty histogram
+        let mut h = self
+            .merged
+            .as_ref()
+            .expect("local histogram None outside phase shift")
+            .clone();
+        h.clear();
+
+        // new recorder starts at the current phase
+        Recorder {
+            local: h,
+            shared: self.shared.clone(),
+            last_phase: self.shared.phase.load(atomic::Ordering::Acquire),
+        }
+    }
+}
+
+impl<C: Counter> From<Histogram<C>> for SyncHistogram<C> {
+    fn from(h: Histogram<C>) -> Self {
+        SyncHistogram {
+            merged: Some(h),
+            shared: Arc::new(Shared {
+                truth: Mutex::new(Critical {
+                    merged: None,
+                    recorders: 0,
+                    phased: 0,
+                }),
+                all_phased: Condvar::new(),
+                phase: atomic::AtomicUsize::new(0),
+            }),
+        }
+    }
+}
+
+use std::ops::{Deref, DerefMut};
+impl<C: Counter> Deref for SyncHistogram<C> {
+    type Target = Histogram<C>;
+    fn deref(&self) -> &Self::Target {
+        self.merged
+            .as_ref()
+            .expect("local histogram None outside phase shift")
+    }
+}
+
+impl<C: Counter> DerefMut for SyncHistogram<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.merged
+            .as_mut()
+            .expect("local histogram None outside phase shift")
+    }
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,0 +1,135 @@
+//! Tests from RecorderTest.java
+
+use hdrhistogram::{sync::SyncHistogram, Histogram};
+use std::sync::Arc;
+use std::{thread, time};
+
+const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
+// Store up to 2 * 10^3 in single-unit precision. Can be 5 at most.
+const SIGFIG: u8 = 3;
+const TEST_VALUE_LEVEL: u64 = 4;
+
+#[test]
+fn record_through() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+    h.record(TEST_VALUE_LEVEL).unwrap();
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+    assert_eq!(h.len(), 1);
+}
+
+#[test]
+fn recorder_drop() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+    let mut r = h.recorder();
+    let jh = thread::spawn(move || {
+        r += TEST_VALUE_LEVEL;
+    });
+    h.phase();
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+    assert_eq!(h.len(), 1);
+    jh.join().unwrap();
+}
+
+#[test]
+fn record_nodrop() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+    let barrier = Arc::new(std::sync::Barrier::new(2));
+    let mut r = h.recorder();
+    let b = Arc::clone(&barrier);
+    let jh = thread::spawn(move || {
+        r += TEST_VALUE_LEVEL;
+        b.wait();
+    });
+    h.phase();
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+    assert_eq!(h.len(), 1);
+    barrier.wait();
+    jh.join().unwrap();
+}
+
+#[test]
+fn phase_timeout() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+    h.record(TEST_VALUE_LEVEL).unwrap();
+    let mut r = h.recorder();
+    r += TEST_VALUE_LEVEL;
+    h.phase_timeout(time::Duration::from_millis(100));
+
+    // second TEST_VALUE_LEVEL should not be visible
+    // since no record happened after phase()
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+    assert_eq!(h.len(), 1);
+}
+
+#[test]
+fn recorder_synchronize() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+
+    let barrier = Arc::new(std::sync::Barrier::new(2));
+    let mut r = h.recorder();
+    let b = Arc::clone(&barrier);
+    let jh = thread::spawn(move || {
+        let n = 10_000;
+        for _ in 0..n {
+            r += TEST_VALUE_LEVEL;
+        }
+        // one of the writes above will unblock the reader's first phase
+        // the 1st barrier below ensures that the reader's second phase isn't passed by a write too
+        // the 2nd barrier below ensures that there is at least one write to synchronize,
+        // and that that write doesn't wake up the 2nd phase
+        b.wait();
+        r += TEST_VALUE_LEVEL;
+        b.wait();
+        r.synchronize();
+        n + 1
+    });
+    h.phase(); // this should be unblocked by one of the writes
+    barrier.wait();
+    barrier.wait();
+    h.phase(); // this will be unblocked by, and will unblock, the synchronize
+    let n = jh.join().unwrap();
+    h.phase(); // no recorders, so we should be fine
+
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), n);
+    assert_eq!(h.len(), n);
+}
+
+#[test]
+fn phase_no_wait_after_drop() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+
+    {
+        let _ = h.recorder();
+    }
+    h.phase(); // this shouldn't block since the recorder went away
+
+    assert_eq!(h.len(), 0);
+}
+
+#[test]
+fn concurrent_writes() {
+    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+        .unwrap()
+        .into();
+    h.record(TEST_VALUE_LEVEL).unwrap();
+    let mut r = h.recorder();
+    r += TEST_VALUE_LEVEL;
+    h.phase_timeout(time::Duration::from_millis(100));
+
+    // second TEST_VALUE_LEVEL should not be visible
+    // since no record happened after phase()
+    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+    assert_eq!(h.len(), 1);
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,279 +1,280 @@
-//! Tests from RecorderTest.java
+#[cfg(all(feature = "sync", test))]
+mod sync {
+    use hdrhistogram::{sync::SyncHistogram, Histogram};
+    use std::sync::Arc;
+    use std::{thread, time};
 
-use hdrhistogram::{sync::SyncHistogram, Histogram};
-use std::sync::Arc;
-use std::{thread, time};
+    const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
+    // Store up to 2 * 10^3 in single-unit precision. Can be 5 at most.
+    const SIGFIG: u8 = 3;
+    const TEST_VALUE_LEVEL: u64 = 4;
 
-const TRACKABLE_MAX: u64 = 3600 * 1000 * 1000;
-// Store up to 2 * 10^3 in single-unit precision. Can be 5 at most.
-const SIGFIG: u8 = 3;
-const TEST_VALUE_LEVEL: u64 = 4;
-
-#[test]
-fn record_through() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-    h.record(TEST_VALUE_LEVEL).unwrap();
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
-}
-
-#[test]
-fn recorder_drop() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-    let mut r = h.recorder();
-    let jh = thread::spawn(move || {
-        r += TEST_VALUE_LEVEL;
-    });
-    h.refresh();
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
-    jh.join().unwrap();
-}
-
-#[test]
-fn record_nodrop() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-    let barrier = Arc::new(std::sync::Barrier::new(2));
-    let mut r = h.recorder();
-    let b = Arc::clone(&barrier);
-    let jh = thread::spawn(move || {
-        r += TEST_VALUE_LEVEL;
-        b.wait();
-    });
-    h.refresh();
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
-    barrier.wait();
-    jh.join().unwrap();
-}
-
-#[test]
-fn phase_timeout() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-    h.record(TEST_VALUE_LEVEL).unwrap();
-    let mut r = h.recorder();
-    r += TEST_VALUE_LEVEL;
-    h.refresh_timeout(time::Duration::from_millis(100));
-
-    // second TEST_VALUE_LEVEL should not be visible
-    // since no record happened after phase()
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
-}
-
-#[test]
-fn recorder_synchronize() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    let barrier = Arc::new(std::sync::Barrier::new(2));
-    let mut r = h.recorder();
-    let b = Arc::clone(&barrier);
-    let jh = thread::spawn(move || {
-        let n = 10_000;
-        for _ in 0..n {
-            r += TEST_VALUE_LEVEL;
-        }
-        // one of the writes above will unblock the reader's first phase
-        // the 1st barrier below ensures that the reader's second phase isn't passed by a write too
-        // the 2nd barrier below ensures that there is at least one write to synchronize,
-        // and that that write doesn't wake up the 2nd phase
-        b.wait();
-        r += TEST_VALUE_LEVEL;
-        b.wait();
-        r.synchronize();
-        n + 1
-    });
-    h.refresh(); // this should be unblocked by one of the writes
-    barrier.wait();
-    barrier.wait();
-    h.refresh(); // this will be unblocked by, and will unblock, the synchronize
-    let n = jh.join().unwrap();
-    h.refresh(); // no recorders, so we should be fine
-
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), n);
-    assert_eq!(h.len(), n);
-}
-
-#[test]
-fn phase_no_wait_after_drop() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    {
-        let _ = h.recorder();
+    #[test]
+    fn record_through() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+        h.record(TEST_VALUE_LEVEL).unwrap();
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
     }
-    h.refresh(); // this shouldn't block since the recorder went away
 
-    assert_eq!(h.len(), 0);
-}
+    #[test]
+    fn recorder_drop() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+        let mut r = h.recorder();
+        let jh = thread::spawn(move || {
+            r += TEST_VALUE_LEVEL;
+        });
+        h.refresh();
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
+        jh.join().unwrap();
+    }
 
-#[test]
-fn mt_record_static() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
+    #[test]
+    fn record_nodrop() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let mut r = h.recorder();
+        let b = Arc::clone(&barrier);
+        let jh = thread::spawn(move || {
+            r += TEST_VALUE_LEVEL;
+            b.wait();
+        });
+        h.refresh();
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
+        barrier.wait();
+        jh.join().unwrap();
+    }
 
-    let n = 16;
-    let barrier = Arc::new(std::sync::Barrier::new(n + 1));
-    let jhs: Vec<_> = (0..n)
-        .map(|_| {
-            let mut r = h.recorder();
-            let barrier = Arc::clone(&barrier);
-            thread::spawn(move || {
-                let n = 100_000;
-                for _ in 0..n {
-                    r += TEST_VALUE_LEVEL;
-                }
-                barrier.wait();
-                r.synchronize();
-                n
-            })
-        })
-        .collect();
-
-    barrier.wait();
-    h.refresh();
-
-    assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
-}
-
-#[test]
-fn no_block_empty_sync() {
-    let h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    h.recorder().synchronize();
-}
-
-#[test]
-fn refresh_times_out() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    let _r = h.recorder();
-    h.refresh_timeout(time::Duration::from_millis(100));
-}
-
-#[test]
-fn mt_record_dynamic() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    let n = 16;
-    let barrier = Arc::new(std::sync::Barrier::new(n + 1));
-    let jhs: Vec<_> = (0..n)
-        .map(|_| {
-            let mut r = h.recorder();
-            let barrier = Arc::clone(&barrier);
-            thread::spawn(move || {
-                let n = 30_000;
-                for i in 0..n {
-                    if i % 1_000 == 0 {
-                        let r2 = r.clone();
-                        let mut r2 = std::mem::replace(&mut r, r2);
-                        thread::spawn(move || {
-                            r2.synchronize();
-                        });
-                    }
-                    r += TEST_VALUE_LEVEL;
-                }
-                barrier.wait();
-                r.synchronize();
-                n as u64
-            })
-        })
-        .collect();
-
-    barrier.wait();
-    h.refresh();
-
-    assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
-}
-
-#[test]
-fn idle_recorder() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-
-    let barrier = Arc::new(std::sync::Barrier::new(2));
-    let mut r = h.recorder();
-    let i = r.idle();
-    h.refresh(); // this should not block
-    h.refresh(); // nor should this
-    drop(i);
-    let b = Arc::clone(&barrier);
-    let jh = thread::spawn(move || {
+    #[test]
+    fn phase_timeout() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+        h.record(TEST_VALUE_LEVEL).unwrap();
+        let mut r = h.recorder();
         r += TEST_VALUE_LEVEL;
-        b.wait();
-        r.synchronize();
-    });
-    barrier.wait();
-    h.refresh(); // this will block!
+        h.refresh_timeout(time::Duration::from_millis(100));
 
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
-    jh.join().unwrap();
-}
+        // second TEST_VALUE_LEVEL should not be visible
+        // since no record happened after phase()
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
+    }
 
-#[test]
-fn mt_record_dynamic_nosync() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
+    #[test]
+    fn recorder_synchronize() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
 
-    let n = 16;
-    let barrier = Arc::new(std::sync::Barrier::new(n + 1));
-    let jhs: Vec<_> = (0..n)
-        .map(|_| {
-            let mut r = h.recorder();
-            let barrier = Arc::clone(&barrier);
-            thread::spawn(move || {
-                let n = 30_000;
-                for i in 0..n {
-                    if i % 1_000 == 0 {
-                        r = r.clone();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let mut r = h.recorder();
+        let b = Arc::clone(&barrier);
+        let jh = thread::spawn(move || {
+            let n = 10_000;
+            for _ in 0..n {
+                r += TEST_VALUE_LEVEL;
+            }
+            // one of the writes above will unblock the reader's first phase
+            // the 1st barrier below ensures that the reader's second phase isn't passed by a write too
+            // the 2nd barrier below ensures that there is at least one write to synchronize,
+            // and that that write doesn't wake up the 2nd phase
+            b.wait();
+            r += TEST_VALUE_LEVEL;
+            b.wait();
+            r.synchronize();
+            n + 1
+        });
+        h.refresh(); // this should be unblocked by one of the writes
+        barrier.wait();
+        barrier.wait();
+        h.refresh(); // this will be unblocked by, and will unblock, the synchronize
+        let n = jh.join().unwrap();
+        h.refresh(); // no recorders, so we should be fine
+
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), n);
+        assert_eq!(h.len(), n);
+    }
+
+    #[test]
+    fn phase_no_wait_after_drop() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        {
+            let _ = h.recorder();
+        }
+        h.refresh(); // this shouldn't block since the recorder went away
+
+        assert_eq!(h.len(), 0);
+    }
+
+    #[test]
+    fn mt_record_static() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        let n = 16;
+        let barrier = Arc::new(std::sync::Barrier::new(n + 1));
+        let jhs: Vec<_> = (0..n)
+            .map(|_| {
+                let mut r = h.recorder();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let n = 100_000;
+                    for _ in 0..n {
+                        r += TEST_VALUE_LEVEL;
                     }
-                    r += TEST_VALUE_LEVEL;
-                }
-                barrier.wait();
-                n as u64
+                    barrier.wait();
+                    r.synchronize();
+                    n
+                })
             })
-        })
-        .collect();
+            .collect();
 
-    barrier.wait();
-    h.refresh();
+        barrier.wait();
+        h.refresh();
 
-    assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
-}
+        assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
+    }
 
-#[test]
-fn concurrent_writes() {
-    let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
-        .unwrap()
-        .into();
-    h.record(TEST_VALUE_LEVEL).unwrap();
-    let mut r = h.recorder();
-    r += TEST_VALUE_LEVEL;
-    h.refresh_timeout(time::Duration::from_millis(100));
+    #[test]
+    fn no_block_empty_sync() {
+        let h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
 
-    // second TEST_VALUE_LEVEL should not be visible
-    // since no record happened after phase()
-    assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
-    assert_eq!(h.len(), 1);
+        h.recorder().synchronize();
+    }
+
+    #[test]
+    fn refresh_times_out() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        let _r = h.recorder();
+        h.refresh_timeout(time::Duration::from_millis(100));
+    }
+
+    #[test]
+    fn mt_record_dynamic() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        let n = 16;
+        let barrier = Arc::new(std::sync::Barrier::new(n + 1));
+        let jhs: Vec<_> = (0..n)
+            .map(|_| {
+                let mut r = h.recorder();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let n = 30_000;
+                    for i in 0..n {
+                        if i % 1_000 == 0 {
+                            let r2 = r.clone();
+                            let mut r2 = std::mem::replace(&mut r, r2);
+                            thread::spawn(move || {
+                                r2.synchronize();
+                            });
+                        }
+                        r += TEST_VALUE_LEVEL;
+                    }
+                    barrier.wait();
+                    r.synchronize();
+                    n as u64
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        h.refresh();
+
+        assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
+    }
+
+    #[test]
+    fn idle_recorder() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let mut r = h.recorder();
+        let i = r.idle();
+        h.refresh(); // this should not block
+        h.refresh(); // nor should this
+        drop(i);
+        let b = Arc::clone(&barrier);
+        let jh = thread::spawn(move || {
+            r += TEST_VALUE_LEVEL;
+            b.wait();
+            r.synchronize();
+        });
+        barrier.wait();
+        h.refresh(); // this will block!
+
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
+        jh.join().unwrap();
+    }
+
+    #[test]
+    fn mt_record_dynamic_nosync() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+
+        let n = 16;
+        let barrier = Arc::new(std::sync::Barrier::new(n + 1));
+        let jhs: Vec<_> = (0..n)
+            .map(|_| {
+                let mut r = h.recorder();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let n = 30_000;
+                    for i in 0..n {
+                        if i % 1_000 == 0 {
+                            r = r.clone();
+                        }
+                        r += TEST_VALUE_LEVEL;
+                    }
+                    barrier.wait();
+                    n as u64
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        h.refresh();
+
+        assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
+    }
+
+    #[test]
+    fn concurrent_writes() {
+        let mut h: SyncHistogram<_> = Histogram::<u64>::new_with_max(TRACKABLE_MAX, SIGFIG)
+            .unwrap()
+            .into();
+        h.record(TEST_VALUE_LEVEL).unwrap();
+        let mut r = h.recorder();
+        r += TEST_VALUE_LEVEL;
+        h.refresh_timeout(time::Duration::from_millis(100));
+
+        // second TEST_VALUE_LEVEL should not be visible
+        // since no record happened after phase()
+        assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
+        assert_eq!(h.len(), 1);
+    }
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -28,7 +28,7 @@ fn recorder_drop() {
     let jh = thread::spawn(move || {
         r += TEST_VALUE_LEVEL;
     });
-    h.phase();
+    h.refresh();
     assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
     assert_eq!(h.len(), 1);
     jh.join().unwrap();
@@ -46,7 +46,7 @@ fn record_nodrop() {
         r += TEST_VALUE_LEVEL;
         b.wait();
     });
-    h.phase();
+    h.refresh();
     assert_eq!(h.count_at(TEST_VALUE_LEVEL), 1);
     assert_eq!(h.len(), 1);
     barrier.wait();
@@ -61,7 +61,7 @@ fn phase_timeout() {
     h.record(TEST_VALUE_LEVEL).unwrap();
     let mut r = h.recorder();
     r += TEST_VALUE_LEVEL;
-    h.phase_timeout(time::Duration::from_millis(100));
+    h.refresh_timeout(time::Duration::from_millis(100));
 
     // second TEST_VALUE_LEVEL should not be visible
     // since no record happened after phase()
@@ -93,12 +93,12 @@ fn recorder_synchronize() {
         r.synchronize();
         n + 1
     });
-    h.phase(); // this should be unblocked by one of the writes
+    h.refresh(); // this should be unblocked by one of the writes
     barrier.wait();
     barrier.wait();
-    h.phase(); // this will be unblocked by, and will unblock, the synchronize
+    h.refresh(); // this will be unblocked by, and will unblock, the synchronize
     let n = jh.join().unwrap();
-    h.phase(); // no recorders, so we should be fine
+    h.refresh(); // no recorders, so we should be fine
 
     assert_eq!(h.count_at(TEST_VALUE_LEVEL), n);
     assert_eq!(h.len(), n);
@@ -113,7 +113,7 @@ fn phase_no_wait_after_drop() {
     {
         let _ = h.recorder();
     }
-    h.phase(); // this shouldn't block since the recorder went away
+    h.refresh(); // this shouldn't block since the recorder went away
 
     assert_eq!(h.len(), 0);
 }
@@ -143,7 +143,7 @@ fn mt_record_static() {
         .collect();
 
     barrier.wait();
-    h.phase();
+    h.refresh();
 
     assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
 }
@@ -180,7 +180,7 @@ fn mt_record_dynamic() {
         .collect();
 
     barrier.wait();
-    h.phase();
+    h.refresh();
 
     assert_eq!(h.len(), jhs.into_iter().map(|r| r.join().unwrap()).sum());
 }
@@ -193,7 +193,7 @@ fn concurrent_writes() {
     h.record(TEST_VALUE_LEVEL).unwrap();
     let mut r = h.recorder();
     r += TEST_VALUE_LEVEL;
-    h.phase_timeout(time::Duration::from_millis(100));
+    h.refresh_timeout(time::Duration::from_millis(100));
 
     // second TEST_VALUE_LEVEL should not be visible
     // since no record happened after phase()


### PR DESCRIPTION
This PR introduces a starting point for multi-threaded histogram recorders ala those supported by [Java's `Recorder`](https://static.javadoc.io/org.hdrhistogram/HdrHistogram/2.1.11/org/HdrHistogram/Recorder.html). The `Recorder` implementation in this PR is somewhat different from the Java version though, as outlined below.

The basic design here is as follows: each `Recorder` keeps a regular (i.e., non-atomic) local `Histogram`. All recorded samples go to that histogram, so common-case recording should be very fast. On every write, the `Recorder` also checks a shared atomic numeric counter, `phase`, which indicates which phase the (one) reader is currently in. Normally, this phase is static, so the read will incur not cross-core traffic, and is wait-free. The reader (`SyncHistogram`) also keeps a regular (non-atomic) local `Histogram`, and all reads go to that histogram, incurring no synchronization cost.

As discussed thus far, the reader never sees any recorded samples, which seems problematic. The reader therefore has a `refresh` operation available to them. When `refresh` is called, the next write to each `Recorder` triggers a "phase shift", where all samples are merged into the reader's map. Each `Recorder` swaps out their histogram with an empty one, and sends the full one over an unbounded channel that the reader reads from. Once the reader has received histograms from each `Recorder` instance, `refresh` returns, and the reader observes all the recorded samples.

The assumption here is that calls to `refresh` are rare compared to calls to the `record` methods. `Recorder`s _only_ pay a cost when a reader wants up-to-date samples.

The current design requires _all_ `Recorder` instances to perform writes continuously to avoid blocking a `refresh`. The `Recorder::idle` method provides one escape-hatch for this, but it's still pretty unwieldy. `SyncHistogram::refresh_timeout` gives readers a way to avoid blocking perpetually, but is a suboptimal solution.

Unfortunately, it is not clear to me at the moment how we avoid this. Sadly I think it would be quite expensive to allow the reader to forcibly merge a `Recorder`'s state, even if the reader could somehow detect that a given `Recorder` is idle. It basically requires either double-buffering (each `Recorder` keeps two histograms, and the reader forces them to swap between them), or a histogram with concurrent (atomic) counter values, neither of which are great. It might be that you can get to a good place by having each `Recorder` keep a `ConcurrentHistogram` (i.e., one that uses atomics for every counter), but that is also _significantly_ more work, so I'll leave that as future work.

The current implementation also does not interact with intervals in any meaningful way, which I _believe_ the Java implementation does.

Given all this, I'm inclined to land this first iteration as a starting point. The API seems reasonable, and we could always improve the implementation later. The `Recorder::idle`, and `SyncHistogram::phase_timeout` should also allow users to not have to worry too much about blocking issues. It basically gives bounded staleness, and lets the user control the bounds. I _think_ the external API is also what we'll want for `Recorder` even with a more elaborate underlying implementation, so I believe it's fine to use the name `Recorder`. Alternative names for methods and for `SyncHistogram` are welcome.

Fixes #51.