### PR TITLE
Migration to Nom5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 rust:
-  - 1.32.0 # uniform paths
+  - 1.34.0 # uniform paths
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0", optional = true }
-nom = { version = "^4.0", optional = true }
+nom = { version = "5.0", optional = true }
 base64 = { version = "0.10", optional = true }
 crossbeam-channel = { version = "0.3", optional = true }
 


### PR DESCRIPTION
Migration was done in 2 parts:
- migration to nom 5 procedure macros
- migration to nom 5 functions

Some missing macros were replaced by the combination of another macros:
- **take_until_and_consume** ->  **take_until** + **take**
- **alt_complete** -> **complete** + **alt**

Missing variant **ErrorKind::Custom** was replaced with **ErrorKind::Alpha**

Some macros were replaced by the combination of functions:
- **do_parse** -> **map** + **tuple**
- **parse_to** -> **map_res** + **u64::from_str** + **map_res** + **str::from_utf8**

Closes #83