### PR TITLE
implement fmt::Display and std::error::Error for all internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+### Added
+- `std::error:Error` implementation for internal Error types: `CreationError`, `AdditionError`, `SubtractionError`, `RecordError`, `UsizeTypeTooSmall`, `DeserializeError`, `IntervalLogWriterError`, `V2DeflateSerializeError`, `V2SerializeError`
+- Changelog
+
+### Changed
+- `DeserializeError` and `V2DeflateSerializeError` lost derived traits: `PartialEq`, `Eq`, `Clone`, `Copy`
+- Inner error type from `std::io::ErrorKind` to `std::io::Error` in types: `DeserializeError`, `V2DeflateSerializeError`, `V2SerializeError`, `IntervalLogWriterError` to support `Display`.
+
+### Removed

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,4 +1,6 @@
 //! Error types used throughout this library
+use std::error::Error;
+use std::fmt;
 
 /// Errors that can occur when creating a histogram.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -69,4 +71,64 @@ pub enum RecordError {
 }
 
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct UsizeTypeTooSmall;
+
+impl fmt::Display for CreationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CreationError::LowIsZero => write!(f, "Lowest discernible value must be >= 1"),
+            CreationError::LowExceedsMax => write!(f, "Lowest discernible value must be <= `u64::max_value() / 2`"),
+            CreationError::HighLessThanTwiceLow => write!(f, "Highest trackable value must be >= 2 * lowest discernible value for some internal calculations"),
+            CreationError::SigFigExceedsMax => write!(f, "Number of significant digits must be in the range `[0, 5]`"),
+            CreationError::CannotRepresentSigFigBeyondLow => write!(f, "Cannot represent sigfig worth of values beyond the lowest discernible value"),
+            CreationError::UsizeTypeTooSmall =>  write!(f, "The `usize` type is too small to represent the desired configuration"),
+        }
+    }
+}
+
+impl Error for CreationError {}
+
+impl fmt::Display for AdditionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AdditionError::OtherAddendValueExceedsRange => write!(f, "The other histogram includes values that do not fit in this histogram's range"),
+            AdditionError::ResizeFailedUsizeTypeTooSmall => write!(f, "The other histogram includes values that would map to indexes in this histogram that are not expressible for `usize`"),
+        }
+    }
+}
+
+impl Error for AdditionError {}
+
+impl fmt::Display for SubtractionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SubtractionError::SubtrahendValueExceedsMinuendRange => write!(f, "The other histogram includes values that do not fit in this histogram's range"),
+            SubtractionError::SubtrahendCountExceedsMinuendCount => write!(f, "The other histogram includes counts that are higher than the current count for a value, and counts cannot go negative"),
+        }
+    }
+}
+
+impl Error for SubtractionError {}
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RecordError::ValueOutOfRangeResizeDisabled  => write!(f, "The value to record is not representable in this histogram and resizing is disabled"),
+            RecordError::ResizeFailedUsizeTypeTooSmall => write!(f, "Auto resizing is enabled and must be used to represent the provided value, but the histogram cannot be resized because `usize` cannot represent sufficient length"),
+        }
+    }
+}
+
+impl Error for RecordError {}
+
+impl fmt::Display for UsizeTypeTooSmall {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "The `usize` type is too small to represent the desired configuration"
+        )
+    }
+}
+
+impl Error for UsizeTypeTooSmall {}

--- a/src/serialization/deserializer.rs
+++ b/src/serialization/deserializer.rs
@@ -3,9 +3,9 @@ use crate::{Counter, Histogram, RestatState};
 use byteorder::{BigEndian, ReadBytesExt};
 use flate2::read::ZlibDecoder;
 use num_traits::ToPrimitive;
-use std;
 use std::io::{self, Cursor, ErrorKind, Read};
 use std::marker::PhantomData;
+use std::{self, error, fmt};
 
 /// Errors that can happen during deserialization.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -33,6 +33,40 @@ impl std::convert::From<std::io::Error> for DeserializeError {
         DeserializeError::IoError(e.kind())
     }
 }
+
+impl fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DeserializeError::IoError(e) => write!(f, "An i/o operation failed: {:?}", e),
+            DeserializeError::InvalidCookie => write!(
+                f,
+                "The cookie (first 4 bytes) did not match that for any supported format"
+            ),
+            DeserializeError::UnsupportedFeature => write!(
+                f,
+                "The histogram uses features that this implementation doesn't support"
+            ),
+            DeserializeError::UnsuitableCounterType => write!(
+                f,
+                "A count exceeded what can be represented in the chosen counter type"
+            ),
+            DeserializeError::InvalidParameters => write!(
+                f,
+                "The serialized parameters were invalid(e.g. lowest value, highest value, etc)"
+            ),
+            DeserializeError::UsizeTypeTooSmall => write!(
+                f,
+                "The current system's pointer width cannot represent the encoded histogram"
+            ),
+            DeserializeError::EncodedArrayTooLong => write!(
+                f,
+                "The encoded array is longer than it should be for the histogram's value range"
+            ),
+        }
+    }
+}
+
+impl error::Error for DeserializeError {}
 
 /// Deserializer for all supported formats.
 ///

--- a/src/serialization/interval_log/mod.rs
+++ b/src/serialization/interval_log/mod.rs
@@ -212,6 +212,7 @@
 //! ```
 
 use std::cmp::Ordering;
+use std::error::Error;
 use std::fmt::Write;
 use std::str::FromStr;
 use std::{fmt, io, ops, str, time};
@@ -414,6 +415,19 @@ impl<E> From<io::Error> for IntervalLogWriterError<E> {
         IntervalLogWriterError::IoError(e.kind())
     }
 }
+
+impl<E: fmt::Display + fmt::Debug> fmt::Display for IntervalLogWriterError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            IntervalLogWriterError::SerializeError(e) => {
+                write!(f, "Histogram serialization failed: {}", e)
+            }
+            IntervalLogWriterError::IoError(e) => write!(f, "An i/o error occurred: {:?}", e),
+        }
+    }
+}
+
+impl<E: fmt::Display + fmt::Debug> Error for IntervalLogWriterError<E> {}
 
 /// Write interval logs.
 struct InternalLogWriter<'a, 'b, W: 'a + io::Write, S: 'b + Serializer> {

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -279,8 +279,8 @@ fn encode_counts_count_too_big() {
     // first position
     h.record_n(0, i64::max_value() as u64 + 1).unwrap();
     assert_eq!(
-        V2SerializeError::CountNotSerializable,
-        encode_counts(&h, &mut vec[..]).unwrap_err()
+        V2SerializeError::CountNotSerializable.to_string(),
+        encode_counts(&h, &mut vec[..]).unwrap_err().to_string()
     );
 }
 

--- a/src/serialization/v2_deflate_serializer.rs
+++ b/src/serialization/v2_deflate_serializer.rs
@@ -5,8 +5,8 @@ use crate::Histogram;
 use byteorder::{BigEndian, WriteBytesExt};
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
-use std;
 use std::io::{ErrorKind, Write};
+use std::{self, error, fmt};
 
 /// Errors that occur during serialization.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -22,6 +22,21 @@ impl std::convert::From<std::io::Error> for V2DeflateSerializeError {
         V2DeflateSerializeError::IoError(e.kind())
     }
 }
+
+impl fmt::Display for V2DeflateSerializeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            V2DeflateSerializeError::InternalSerializationError(e) => {
+                write!(f, "The underlying serialization failed: {}", e)
+            }
+            V2DeflateSerializeError::IoError(e) => {
+                write!(f, "The underlying serialization failed: {:?}", e)
+            }
+        }
+    }
+}
+
+impl error::Error for V2DeflateSerializeError {}
 
 /// Serializer for the V2 + DEFLATE binary format.
 ///

--- a/src/serialization/v2_deflate_serializer.rs
+++ b/src/serialization/v2_deflate_serializer.rs
@@ -5,21 +5,21 @@ use crate::Histogram;
 use byteorder::{BigEndian, WriteBytesExt};
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
-use std::io::{ErrorKind, Write};
+use std::io::{self, Write};
 use std::{self, error, fmt};
 
 /// Errors that occur during serialization.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug)]
 pub enum V2DeflateSerializeError {
     /// The underlying serialization failed
     InternalSerializationError(V2SerializeError),
     /// An i/o operation failed.
-    IoError(ErrorKind),
+    IoError(io::Error),
 }
 
 impl std::convert::From<std::io::Error> for V2DeflateSerializeError {
     fn from(e: std::io::Error) -> Self {
-        V2DeflateSerializeError::IoError(e.kind())
+        V2DeflateSerializeError::IoError(e)
     }
 }
 
@@ -30,13 +30,20 @@ impl fmt::Display for V2DeflateSerializeError {
                 write!(f, "The underlying serialization failed: {}", e)
             }
             V2DeflateSerializeError::IoError(e) => {
-                write!(f, "The underlying serialization failed: {:?}", e)
+                write!(f, "The underlying serialization failed: {}", e)
             }
         }
     }
 }
 
-impl error::Error for V2DeflateSerializeError {}
+impl error::Error for V2DeflateSerializeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            V2DeflateSerializeError::InternalSerializationError(e) => Some(e),
+            V2DeflateSerializeError::IoError(e) => Some(e),
+        }
+    }
+}
 
 /// Serializer for the V2 + DEFLATE binary format.
 ///


### PR DESCRIPTION
Closes #81

Initial implementations:
- error messages were taken from the first sentences of documentation strings.
- underlined **io::ErrorKind** does not have **Display** and **to_string**, while **as_str** is available, but private, so **Debug** representation was taken.

Proposition:
- replace ErrorKind with original **io::Error**, which already has **Display** implementation.