### PR TITLE
Update base64 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdrhistogram"
-version = "7.0.0"
+version = "7.0.1"
 edition = "2018"
 
 description = "A port of HdrHistogram to Rust"
@@ -35,7 +35,7 @@ num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0", optional = true }
 nom = { version = "5.0", optional = true }
-base64 = { version = "0.11", optional = true }
+base64 = { version = "0.12", optional = true }
 crossbeam-channel = { version = "0.4", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
A small PR which just updates base64 to the up-to-date version.

I'm not sure if the "patch" or "minor" part of the version should be update, so I've topped the "patch" :)