### PR TITLE
Bump nom to 6.1.2 to resolve bitvec->funty conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0", optional = true }
-nom = { version = "6.0.1", optional = true }
+nom = { version = "6.1.2", optional = true }
 base64 = { version = "0.13", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 


### PR DESCRIPTION
This includes https://github.com/Geal/nom/pull/1286 which is a fix for https://github.com/myrrlyn/funty/issues/3