### PR TITLE
Update nom to 7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0", optional = true }
-nom = { version = "6.0.1", optional = true }
+nom = { version = "7.0.0", optional = true }
 base64 = { version = "0.13", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 


### PR DESCRIPTION
Motivation: Nom 6 used a version of bitvec using the old (and bad) way of ignoring code via tarpaulin `#[cfg_attr(tarpaulin,skip)]`, unfortunately having this in a users dependency tree means you need to use an older version of tarpaulin or run `--avoid-cfg-tarpaulin` and limits a users ability to filter out code in coverage runs.

This PR updates nom to 7.0.0, it would also be nice for affected tarpaulin users if there could be a new hdrhistogram release after this is merged :pray: 

Some other benefits mentioned in the nom changelog, faster float parsing, better compile times, and slimmer dependencies as bitvec and regex code are moved into separate nom crates to further reduce binary size and compilation time. 