### PR TITLE
Maybe fix interval logs on Windows

### DIFF
--- a/src/serialization/interval_log/mod.rs
+++ b/src/serialization/interval_log/mod.rs
@@ -743,6 +743,8 @@ fn interval_hist(input: &[u8]) -> IResult<&[u8], LogEntry> {
     let (input, max) = double(input)?;
     let (input, _) = char(',')(input)?;
     let (input, encoded_histogram) = map_res(take_until("\n"), str::from_utf8)(input)?;
+    // Be nice to Windows users:
+    let encoded_histogram = encoded_histogram.trim_end_matches('\r');
     let (input, _) = take(1_usize)(input)?;
 
     Ok((


### PR DESCRIPTION
Seems the checked-in test file has `\r\n` line endings on Windows, and
since we consider the encoded histogram as being everything up until the
`\n`, this makes the `\r` part of the encoded, which then makes it
invalid base64!