### PR TITLE
Optimize quantile_below, 100x speedup

### DIFF
--- a/benches/quantiles.rs
+++ b/benches/quantiles.rs
@@ -1,0 +1,19 @@
+#![feature(test)]
+
+extern crate test;
+
+use hdrhistogram::*;
+use test::{black_box, Bencher};
+
+#[bench]
+fn quantiles_below(b: &mut Bencher) {
+    let mut h = Histogram::<u32>::new_with_bounds(1, 100_000, 3).unwrap();
+    for i in 0..100_000 {
+        h.record(i).unwrap();
+    }
+
+    b.iter(|| {
+        black_box(h.quantile_below(black_box(10)));
+        black_box(h.quantile_below(black_box(90_000)));
+    })
+}


### PR DESCRIPTION
Benched with `-Ctarget-cpu=znver2`

```
OLD: test quantiles_below ... bench:       3,618 ns/iter (+/- 54)
NEW: test quantiles_below ... bench:          37 ns/iter (+/- 1)
```