### PR TITLE
Optimize Histogram::clone and in some cases Histogram::add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Changed
+- Optimize `Histogram::clone` ([#113])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Optimize `Histogram::clone` ([#113])
+- Optimize `Histogram::add` when the histogram parameters are equivalent and the target histogram is empty ([#113])
 
 ### Removed
 

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -1,0 +1,16 @@
+#![feature(test)]
+
+extern crate test;
+
+use hdrhistogram::*;
+use test::Bencher;
+
+#[bench]
+fn clone(b: &mut Bencher) {
+    let mut h = Histogram::<u32>::new_with_bounds(1, 100_000, 3).unwrap();
+    for i in 0..100_000 {
+        h.record(i).unwrap();
+    }
+
+    b.iter(|| h.clone())
+}

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -14,3 +14,17 @@ fn clone(b: &mut Bencher) {
 
     b.iter(|| h.clone())
 }
+
+#[bench]
+fn new_from_then_add(b: &mut Bencher) {
+    let mut h = Histogram::<u32>::new_with_bounds(1, 100_000, 3).unwrap();
+    for i in 0..100_000 {
+        h.record(i).unwrap();
+    }
+
+    b.iter(|| {
+        let mut c = Histogram::new_from(&h);
+        c += &h;
+        c
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ const ORIGINAL_MAX: u64 = 0;
 /// = 2048 * 2^(k-1)`, which is the k-1'th bucket's end. So, we would use the previous bucket
 /// for those lower values as it has better precision.
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Histogram<T: Counter> {
     auto_resize: bool,
 
@@ -1765,14 +1765,6 @@ impl<T: Counter> RestatState<T> {
 // ********************************************************************************************
 // Trait implementations
 // ********************************************************************************************
-
-impl<T: Counter> Clone for Histogram<T> {
-    fn clone(&self) -> Self {
-        let mut h = Histogram::new_from(self);
-        h += self;
-        h
-    }
-}
 
 // make it more ergonomic to add and subtract histograms
 impl<'a, T: Counter> AddAssign<&'a Histogram<T>> for Histogram<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,6 +462,11 @@ impl<T: Counter> Histogram<T> {
     pub fn add<B: Borrow<Histogram<T>>>(&mut self, source: B) -> Result<(), AdditionError> {
         let source = source.borrow();
 
+        // If source is empty there's nothing to add
+        if source.is_empty() {
+            return Ok(());
+        }
+
         // make sure we can take the values in source
         let top = self.highest_equivalent(self.value_for(self.last_index()));
         if top < source.max() {
@@ -584,6 +589,11 @@ impl<T: Counter> Histogram<T> {
         subtrahend: B,
     ) -> Result<(), SubtractionError> {
         let subtrahend = subtrahend.borrow();
+
+        // If the source is empty there's nothing to subtract
+        if subtrahend.is_empty() {
+            return Ok(());
+        }
 
         // make sure we can take the values in source
         let top = self.highest_equivalent(self.value_for(self.last_index()));


### PR DESCRIPTION
Optimize Histogram::clone by using a simple derived implementation

Benchmarks for cloning an Histogram created with `Histogram::<u32>::new_with_bounds(1, 100_000, 3)`

Before
`test clone ... bench:       6,513 ns/iter (+/- 66)`
After
`test clone ... bench:         532 ns/iter (+/- 16)`

and also
Optimize Histogram::add when the histogram parameters are equivalent and the target histogram is empty

Before
`test new_from_then_add ... bench:       6,513 ns/iter (+/- 66)`
After
`test new_from_then_add ... bench:         788 ns/iter (+/- 46)`
