### PR TITLE
Fix #124 Record iteration when recording only zeros

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -74,7 +74,7 @@ pub struct HistogramIterator<'a, T: 'a + Counter, P: PickyIterator<T>> {
     count_since_last_iteration: u64,
     count_at_index: T,
     current_index: usize,
-    last_picked_index: usize,
+    last_picked_index: Option<usize>,
     max_value_index: usize,
     fresh: bool,
     ended: bool,
@@ -152,7 +152,7 @@ impl<'a, T: Counter, P: PickyIterator<T>> HistogramIterator<'a, T, P> {
             count_since_last_iteration: 0,
             count_at_index: T::zero(),
             current_index: 0,
-            last_picked_index: 0,
+            last_picked_index: None,
             max_value_index: h.index_for(h.max()).expect("Either 0 or an existing index"),
             picker,
             fresh: true,
@@ -186,7 +186,7 @@ where
             }
 
             // Have we already picked the index with the last non-zero count in the histogram?
-            if self.last_picked_index >= self.max_value_index {
+            if self.last_picked_index >= Some(self.max_value_index) {
                 // is the picker done?
                 if !self.picker.more(self.current_index) {
                     self.ended = true;
@@ -243,7 +243,7 @@ where
                 // step multiple times without advancing the index.
 
                 self.count_since_last_iteration = 0;
-                self.last_picked_index = self.current_index;
+                self.last_picked_index = Some(self.current_index);
                 return Some(val);
             }
 

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -565,5 +565,5 @@ fn subtract_underflow_guarded_by_per_value_count_check() {
 fn recorded_only_zeros() {
     let mut h = Histogram::<u64>::new(1).unwrap();
     h += 0;
-    assert_eq!(h.iter_recorded().collect::<Vec<_>>().len(), 1);
+    assert_eq!(h.iter_recorded().count(), 1);
 }

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -560,3 +560,10 @@ fn subtract_underflow_guarded_by_per_value_count_check() {
         h.subtract(h2).unwrap_err()
     );
 }
+
+#[test]
+fn recorded_only_zeros() {
+    let mut h = Histogram::<u64>::new(1).unwrap();
+    h += 0;
+    assert_eq!(h.iter_recorded().collect::<Vec<_>>().len(), 1);
+}


### PR DESCRIPTION
Fixes #124

As pointed in the comment in the corresponding issues, we want to ensure we trigger the picker logic at least once to keep the invariant of the loop, that is to say that the picking logic has been executed for last_picked_index, which is not the case for zero when there are only zeros.

I added a test that collect the record and check for their count.

Would it be better to check for the following:

```rust
assert_eq!(h.iter_recorded().collect::<Vec<_>>(), vec![IterationValue::<u64>::new(0, 1.0, 1.0, 1, 1)]);
```

It is easy to assume that `h.iter_recorded().collect::<Vec<_>>().len() == h.len()` and simplify the added test, and I'm unsure how to convey that we _really_ want to collect and check the length of all the record.