### PR TITLE
Fix incorrect test simplification.

### DIFF
--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -565,5 +565,12 @@ fn subtract_underflow_guarded_by_per_value_count_check() {
 fn recorded_only_zeros() {
     let mut h = Histogram::<u64>::new(1).unwrap();
     h += 0;
-    assert_eq!(h.iter_recorded().count(), 1);
+    // Do not simplify .collect::<Vec<_>>().len() to .count()
+    // This check a bug where .count() and .collect::<Vec<_>>().len()
+    // are different
+    assert_eq!(h.iter_recorded().collect::<Vec<_>>().len(), 1);
+    assert_eq!(
+        h.iter_recorded().collect::<Vec<_>>().len(),
+        h.iter_recorded().count()
+    );
 }


### PR DESCRIPTION
In https://github.com/HdrHistogram/HdrHistogram_rust/pull/125#discussion_r1390185430 a simplification was made without discussion:

```diff
-     h.iter_recorded().collect::<Vec<_>>().len()
+     h.iter_recorded().count()
```

This is incorrect as what this test actually tests was that the iterator has the correct length. In a perfect world both should be identical but the PR fix a case where this was not the case as some items would be skipped over.

In this I revert the change, add a comment and a second (redundant) check to make sure this is not re-simplified later.