### PR TITLE
refactor: migrate `nom` to `winnow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.4.11"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,10 +205,10 @@ dependencies = [
  "crossbeam-channel",
  "flate2",
  "ieee754",
- "nom",
  "num-traits",
  "rand",
  "rug",
+ "winnow",
 ]
 
 [[package]]
@@ -253,28 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -486,3 +470,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.3.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0.3", optional = true }
-winnow = { version = "0.4", optional = true }
+winnow = { version = "0.5", optional = true }
 base64 = { version = "0.21", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0.3", optional = true }
-winnow = { version = "0.5", optional = true }
+winnow = { version = "0.6", optional = true }
 base64 = { version = "0.21", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 
 [features]
 bench_private = [] # for enabling nightly-only feature(test) on the main crate to allow benchmarking private code
-serialization = [ "flate2", "nom", "base64" ]
+serialization = [ "flate2", "winnow", "base64" ]
 sync = [ "crossbeam-channel" ]
 default = [ "serialization", "sync" ]
 
@@ -30,7 +30,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0.3", optional = true }
-nom = { version = "7.0.0", optional = true }
+winnow = { version = "0.3", optional = true }
 base64 = { version = "0.21", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = [ "serialization", "sync" ]
 num-traits = "0.2"
 byteorder = "1.0.0"
 flate2 = { version = "1.0.3", optional = true }
-winnow = { version = "0.3", optional = true }
+winnow = { version = "0.4", optional = true }
 base64 = { version = "0.21", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,10 +200,6 @@
 #[cfg(all(test, feature = "bench_private"))]
 extern crate test;
 
-#[cfg(feature = "serialization")]
-#[macro_use]
-extern crate nom;
-
 use num_traits::ToPrimitive;
 use std::borrow::Borrow;
 use std::cmp;

--- a/src/serialization/deserializer.rs
+++ b/src/serialization/deserializer.rs
@@ -164,8 +164,8 @@ impl Deserializer {
             self.payload_buf.resize(payload_len, 0);
         }
 
-        let mut payload_slice = &mut self.payload_buf[0..payload_len];
-        reader.read_exact(&mut payload_slice)?;
+        let payload_slice = &mut self.payload_buf[0..payload_len];
+        reader.read_exact(payload_slice)?;
 
         let mut payload_index: usize = 0;
         let mut restat_state = RestatState::new();

--- a/src/serialization/interval_log/mod.rs
+++ b/src/serialization/interval_log/mod.rs
@@ -315,7 +315,7 @@ impl IntervalLogWriterBuilder {
         };
 
         for c in &self.comments {
-            internal_writer.write_comment(&c)?;
+            internal_writer.write_comment(c)?;
         }
 
         if let Some(st) = self.start_time {


### PR DESCRIPTION
## Description

`nom` is no longer maintained, [`winnow`](https://github.com/winnow-rs/winnow) is currently the most active fork in the community, so migrate to `winnow`.

## Prior arts
- [toml-edit](https://github.com/toml-rs/toml/pull/521)
- [gitoxide](https://github.com/Byron/gitoxide/pull/948)