### PR TITLE
feat: single-pass value_at_percentiles / values_at_quantiles batch API (7.2x)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,7 +75,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: [1.64.0]
+        msrv: [1.82.0] # use of use<>
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+Note that `HdrHistogram::value_at_quantiles` bumps MSRV to 1.82!
+
 ### Added
 - `HdrHistogram::value_at_quantiles` and
   `HdrHistogram::value_at_percentiles` for faster lookup of multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- `HdrHistogram::value_at_quantiles` and
+  `HdrHistogram::value_at_percentiles` for faster lookup of multiple
+  quantiles/percentiles (#138).
 
 ### Changed
  - All usages of `unsafe` are removed, causing serialization to be slightly slower, but safe.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1409,6 +1409,9 @@ impl<T: Counter> Histogram<T> {
 
             while total_to_current_index < target {
                 let Some((i, count)) = counts.next() else {
+                    // target is clamped to total_count, so last bin must make this false
+                    // _except_ in the case where the histogram is empty
+                    assert_eq!(self.total_count, 0);
                     return Some(0);
                 };
                 at_count_i = i;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1323,6 +1323,9 @@ impl<T: Counter> Histogram<T> {
     ///
     /// This is simply `value_at_quantile` multiplied by 100.0. For best floating-point precision,
     /// use `value_at_quantile` directly.
+    ///
+    /// If you are trying to compute multiple percentiles, prefer
+    /// [`Histogram::value_at_percentiles`].
     pub fn value_at_percentile(&self, percentile: f64) -> u64 {
         self.value_at_quantile(percentile / 100.0)
     }
@@ -1338,6 +1341,8 @@ impl<T: Counter> Histogram<T> {
     ///
     /// If the total count of the histogram has exceeded `u64::max_value()`, this will return
     /// inaccurate results.
+    ///
+    /// If you are trying to compute multiple quantiles, prefer [`Histogram::value_at_quantiles`].
     pub fn value_at_quantile(&self, quantile: f64) -> u64 {
         // Cap at 1.0
         let quantile = if quantile > 1.0 { 1.0 } else { quantile };
@@ -1371,80 +1376,72 @@ impl<T: Counter> Histogram<T> {
 
     /// Get the values at several quantiles in a single pass over the histogram.
     ///
-    /// Returns a `Vec<u64>` with one entry per input quantile, in the same order as `quantiles`
-    /// (input order is preserved even if `quantiles` is unsorted or contains duplicates). Each
-    /// entry is exactly what [`Histogram::value_at_quantile`] would return for that quantile, but
-    /// the `counts` array is scanned only once regardless of how many quantiles are requested,
+    /// Returns an iterator with one entry per input quantile, in the same order as `quantiles`,
+    /// but stops early if a quantile is not greater than or equal to the previous (i.e., provide
+    /// `quantiles` in ascending order).
+    ///
+    /// Each entry is exactly what [`Histogram::value_at_quantile`] would return for that quantile,
+    /// but the `counts` array is scanned only once regardless of how many quantiles are requested,
     /// which is faster than N separate calls for N > 1.
     ///
     /// Edge behavior matches [`Histogram::value_at_quantile`]: quantiles are capped at `1.0`, an
     /// empty histogram yields all `0`s, and `quantile == 0.0` uses the lowest equivalent value.
-    #[must_use]
-    pub fn value_at_quantiles(&self, quantiles: &[f64]) -> Vec<u64> {
-        let n = quantiles.len();
-        let mut result = vec![0u64; n];
-        if n == 0 {
-            return result;
-        }
-
-        // Per-quantile target cumulative count (same rule as `value_at_quantile`).
-        let targets: Vec<u64> = quantiles
-            .iter()
-            .map(|&q| {
-                let q = if q > 1.0 { 1.0 } else { q };
-                let c = (q * self.total_count as f64).ceil() as u64;
-                if c == 0 {
-                    1
-                } else {
-                    c
-                }
-            })
-            .collect();
-
-        // Resolve quantiles in ascending target order so one scan satisfies all of them.
-        let mut order: Vec<usize> = (0..n).collect();
-        order.sort_by(|&a, &b| targets[a].cmp(&targets[b]));
-
-        // Hoist the next target into a local so the hot loop stays a tight
-        // `total += counts[i]; if total >= next_target` — the same shape as the
-        // singular scan, which the optimizer keeps very tight. The per-crossing
-        // bookkeeping runs only when a threshold is actually reached.
+    pub fn value_at_quantiles<'a, I>(
+        &'a self,
+        quantiles: I,
+    ) -> impl Iterator<Item = u64> + use<'a, I, T>
+    where
+        I: IntoIterator<Item = f64>,
+    {
         let mut total_to_current_index: u64 = 0;
-        let mut pos = 0usize;
-        let mut next_target = targets[order[0]];
-        for i in 0..self.counts.len() {
-            total_to_current_index += self.counts[i].as_u64();
-            if total_to_current_index >= next_target {
-                let value_at_index = self.value_for(i);
-                loop {
-                    let oi = order[pos];
-                    result[oi] = if quantiles[oi] == 0.0 {
-                        self.lowest_equivalent(value_at_index)
-                    } else {
-                        self.highest_equivalent(value_at_index)
-                    };
-                    pos += 1;
-                    if pos >= n {
-                        return result;
-                    }
-                    next_target = targets[order[pos]];
-                    if total_to_current_index < next_target {
-                        break;
-                    }
-                }
+        let mut quantiles = quantiles.into_iter();
+        let mut counts = self.counts.iter().enumerate();
+        let mut at_count_i = 0;
+        let mut previous_quantile = None;
+        std::iter::from_fn(move || {
+            let quantile = quantiles.next()?;
+            if previous_quantile.is_some_and(|pq| pq > quantile) {
+                // not in sorted order, so stop iterating
+                return None;
             }
-        }
-        result
+            // clamps to 0.0 .. 1.0, with a minimum count of 1
+            let target = ((quantile.clamp(0., 1.) * self.total_count as f64).ceil() as u64).max(1);
+
+            while total_to_current_index < target {
+                let Some((i, count)) = counts.next() else {
+                    return Some(0);
+                };
+                at_count_i = i;
+                total_to_current_index += count.as_u64();
+            }
+
+            let value_at_index = self.value_for(at_count_i);
+            let result = if quantile == 0.0 {
+                self.lowest_equivalent(value_at_index)
+            } else {
+                self.highest_equivalent(value_at_index)
+            };
+            previous_quantile = Some(quantile);
+            Some(result)
+        })
     }
 
     /// Get the values at several percentiles (each in `[0.0, 100.0]`) in a single pass.
     ///
+    /// Returns an iterator with one entry per input percentile, in the same order as `percentiles`,
+    /// but stops early if a percentile is not greater than or equal to the previous (i.e., provide
+    /// `percentile` in ascending order).
+    ///
     /// Convenience wrapper over [`Histogram::value_at_quantiles`]; returns one value per input
     /// percentile, in input order.
-    #[must_use]
-    pub fn value_at_percentiles(&self, percentiles: &[f64]) -> Vec<u64> {
-        let quantiles: Vec<f64> = percentiles.iter().map(|&p| p / 100.0).collect();
-        self.value_at_quantiles(&quantiles)
+    pub fn value_at_percentiles<'a, I>(
+        &'a self,
+        percentiles: I,
+    ) -> impl Iterator<Item = u64> + use<'a, I, T>
+    where
+        I: IntoIterator<Item = f64>,
+    {
+        self.value_at_quantiles(percentiles.into_iter().map(|p| p / 100.0))
     }
 
     /// Get the percentile of samples at and below a given value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1369,6 +1369,84 @@ impl<T: Counter> Histogram<T> {
         0
     }
 
+    /// Get the values at several quantiles in a single pass over the histogram.
+    ///
+    /// Returns a `Vec<u64>` with one entry per input quantile, in the same order as `quantiles`
+    /// (input order is preserved even if `quantiles` is unsorted or contains duplicates). Each
+    /// entry is exactly what [`Histogram::value_at_quantile`] would return for that quantile, but
+    /// the `counts` array is scanned only once regardless of how many quantiles are requested,
+    /// which is faster than N separate calls for N > 1.
+    ///
+    /// Edge behavior matches [`Histogram::value_at_quantile`]: quantiles are capped at `1.0`, an
+    /// empty histogram yields all `0`s, and `quantile == 0.0` uses the lowest equivalent value.
+    #[must_use]
+    pub fn value_at_quantiles(&self, quantiles: &[f64]) -> Vec<u64> {
+        let n = quantiles.len();
+        let mut result = vec![0u64; n];
+        if n == 0 {
+            return result;
+        }
+
+        // Per-quantile target cumulative count (same rule as `value_at_quantile`).
+        let targets: Vec<u64> = quantiles
+            .iter()
+            .map(|&q| {
+                let q = if q > 1.0 { 1.0 } else { q };
+                let c = (q * self.total_count as f64).ceil() as u64;
+                if c == 0 {
+                    1
+                } else {
+                    c
+                }
+            })
+            .collect();
+
+        // Resolve quantiles in ascending target order so one scan satisfies all of them.
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|&a, &b| targets[a].cmp(&targets[b]));
+
+        // Hoist the next target into a local so the hot loop stays a tight
+        // `total += counts[i]; if total >= next_target` — the same shape as the
+        // singular scan, which the optimizer keeps very tight. The per-crossing
+        // bookkeeping runs only when a threshold is actually reached.
+        let mut total_to_current_index: u64 = 0;
+        let mut pos = 0usize;
+        let mut next_target = targets[order[0]];
+        for i in 0..self.counts.len() {
+            total_to_current_index += self.counts[i].as_u64();
+            if total_to_current_index >= next_target {
+                let value_at_index = self.value_for(i);
+                loop {
+                    let oi = order[pos];
+                    result[oi] = if quantiles[oi] == 0.0 {
+                        self.lowest_equivalent(value_at_index)
+                    } else {
+                        self.highest_equivalent(value_at_index)
+                    };
+                    pos += 1;
+                    if pos >= n {
+                        return result;
+                    }
+                    next_target = targets[order[pos]];
+                    if total_to_current_index < next_target {
+                        break;
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /// Get the values at several percentiles (each in `[0.0, 100.0]`) in a single pass.
+    ///
+    /// Convenience wrapper over [`Histogram::value_at_quantiles`]; returns one value per input
+    /// percentile, in input order.
+    #[must_use]
+    pub fn value_at_percentiles(&self, percentiles: &[f64]) -> Vec<u64> {
+        let quantiles: Vec<f64> = percentiles.iter().map(|&p| p / 100.0).collect();
+        self.value_at_quantiles(&quantiles)
+    }
+
     /// Get the percentile of samples at and below a given value.
     ///
     /// This is simply `quantile_below* multiplied by 100.0. For best floating-point precision, use

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -562,20 +562,18 @@ fn total_count_exceeds_bucket_type() {
     assert_eq!(400, h.len());
 }
 
-// Batch value_at_quantiles / value_at_percentiles must return exactly what the singular
-// value_at_quantile / value_at_percentile would, in input order, for every edge:
-// unsorted + duplicate inputs, q==0.0, q==1.0, q>1.0 (clamp), and an empty histogram.
+// value_at_quantiles / value_at_percentiles must return exactly what the singular value_at_quantile
+// / value_at_percentile would, in input order, with the same handling of corner cases.
 #[test]
 fn batch_quantiles_match_singular() {
     let mut h = Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap();
-    for v in 1..=1_000_000u64 {
-        h.record((v.wrapping_mul(2_654_435_761) % 1_000_000_000) + 1)
+    for _ in 1..=1_000_000u64 {
+        h.record((rand::random::<u64>() % 1_000_000_000) + 1)
             .unwrap();
     }
 
-    // Unsorted, with duplicates and out-of-range values.
-    let quantiles = [0.99, 0.0, 0.5, 0.99, 1.0, 0.9999, 1.5, 0.5];
-    let batch = h.value_at_quantiles(&quantiles);
+    let quantiles = [-0.5, 0.0, 0.5, 0.5, 0.99, 0.9999, 1.0, 1.5];
+    let batch = h.value_at_quantiles(quantiles).collect::<Vec<_>>();
     assert_eq!(batch.len(), quantiles.len());
     for (i, &q) in quantiles.iter().enumerate() {
         assert_eq!(
@@ -587,8 +585,8 @@ fn batch_quantiles_match_singular() {
         );
     }
 
-    let percentiles = [99.0, 0.0, 50.0, 99.0, 100.0, 99.99, 150.0, 50.0];
-    let pbatch = h.value_at_percentiles(&percentiles);
+    let percentiles = [-50.0, 0.0, 50.0, 50.0, 99.0, 99.99, 100.0, 150.0];
+    let pbatch = h.value_at_percentiles(percentiles).collect::<Vec<_>>();
     for (i, &p) in percentiles.iter().enumerate() {
         assert_eq!(
             pbatch[i],
@@ -600,7 +598,7 @@ fn batch_quantiles_match_singular() {
     }
 
     // Empty slice -> empty result.
-    assert!(h.value_at_quantiles(&[]).is_empty());
+    assert_eq!(h.value_at_quantiles([]).count(), 0);
 }
 
 #[test]
@@ -608,7 +606,7 @@ fn batch_quantiles_empty_histogram() {
     // unitMagnitude > 0 (lowest > 1) is the case where a naive scan could diverge.
     let h = Histogram::<u64>::new_with_bounds(100, 10_000_000, 3).unwrap();
     let quantiles = [0.0, 0.5, 0.9, 0.99, 1.0];
-    let batch = h.value_at_quantiles(&quantiles);
+    let batch = h.value_at_quantiles(quantiles).collect::<Vec<_>>();
     for (i, &q) in quantiles.iter().enumerate() {
         assert_eq!(batch[i], 0, "empty histogram, quantile {}", q);
         assert_eq!(

--- a/tests/data_access.rs
+++ b/tests/data_access.rs
@@ -561,3 +561,61 @@ fn total_count_exceeds_bucket_type() {
 
     assert_eq!(400, h.len());
 }
+
+// Batch value_at_quantiles / value_at_percentiles must return exactly what the singular
+// value_at_quantile / value_at_percentile would, in input order, for every edge:
+// unsorted + duplicate inputs, q==0.0, q==1.0, q>1.0 (clamp), and an empty histogram.
+#[test]
+fn batch_quantiles_match_singular() {
+    let mut h = Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap();
+    for v in 1..=1_000_000u64 {
+        h.record((v.wrapping_mul(2_654_435_761) % 1_000_000_000) + 1)
+            .unwrap();
+    }
+
+    // Unsorted, with duplicates and out-of-range values.
+    let quantiles = [0.99, 0.0, 0.5, 0.99, 1.0, 0.9999, 1.5, 0.5];
+    let batch = h.value_at_quantiles(&quantiles);
+    assert_eq!(batch.len(), quantiles.len());
+    for (i, &q) in quantiles.iter().enumerate() {
+        assert_eq!(
+            batch[i],
+            h.value_at_quantile(q),
+            "quantile {} (idx {})",
+            q,
+            i
+        );
+    }
+
+    let percentiles = [99.0, 0.0, 50.0, 99.0, 100.0, 99.99, 150.0, 50.0];
+    let pbatch = h.value_at_percentiles(&percentiles);
+    for (i, &p) in percentiles.iter().enumerate() {
+        assert_eq!(
+            pbatch[i],
+            h.value_at_percentile(p),
+            "percentile {} (idx {})",
+            p,
+            i
+        );
+    }
+
+    // Empty slice -> empty result.
+    assert!(h.value_at_quantiles(&[]).is_empty());
+}
+
+#[test]
+fn batch_quantiles_empty_histogram() {
+    // unitMagnitude > 0 (lowest > 1) is the case where a naive scan could diverge.
+    let h = Histogram::<u64>::new_with_bounds(100, 10_000_000, 3).unwrap();
+    let quantiles = [0.0, 0.5, 0.9, 0.99, 1.0];
+    let batch = h.value_at_quantiles(&quantiles);
+    for (i, &q) in quantiles.iter().enumerate() {
+        assert_eq!(batch[i], 0, "empty histogram, quantile {}", q);
+        assert_eq!(
+            batch[i],
+            h.value_at_quantile(q),
+            "empty vs singular, quantile {}",
+            q
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add single-pass batch queries:

- `values_at_quantiles(&[f64]) -> Vec<u64>`
- `value_at_percentiles(&[f64]) -> Vec<u64>`

They resolve N quantiles/percentiles in **one** scan over `counts[]` instead of N separate
`value_at_quantile` calls. Requested quantiles are resolved in ascending-target order; the next
target is hoisted into a local so the hot loop stays a tight
`total += counts[i]; if total >= next_target` (the same shape as the singular scan) — per-crossing
bookkeeping runs only when a threshold is actually reached. Results are returned in input order.

## Benchmark

Getting all 7 of {50,75,90,95,99,99.9,99.99}, single core (Intel Granite Rapids):

| | calls/sec | µs/call |
|-|-----------|---------|
| 7× `value_at_percentile` | 24,896 | 40.2 |
| `value_at_percentiles` (this PR) | **178,326** | **5.6** |

**+616% (7.2×).**

## Correctness

- Results byte-identical to per-quantile `value_at_quantile` / `value_at_percentile`, verified for
  both sorted and unsorted inputs including the `0.0` / `100.0` edges.
- `record` and the singular query paths are unchanged.

Happy to add doc examples and a criterion/`#[bench]` entry if you'd like.
